### PR TITLE
Add dependencies

### DIFF
--- a/dwarftherapist.spec
+++ b/dwarftherapist.spec
@@ -11,6 +11,7 @@ License:	MIT
 Source: https://github.com/%{repo_owner}/%{repo_name}/archive/v%{version}/%{name}-%{version}.tar.gz
 Patch0: 0001-remove-readme-license.patch
 
+Requires: compat-openssl10-devel
 BuildRequires: cmake, gcc-c++, qt5-qtbase-devel, qt5-qtdeclarative-devel
 
 


### PR DESCRIPTION
While working on a fedora package for a dwarf fortress pack, we ended up hitting the following errors when executing dwarf_therapist:

```
2020-Jun-24 17:42:50.509 INFO	core	Runtime QT Version 5.2.1 [src/dwarftherapist.cpp:208] (setup_logging)
QSslSocket: cannot resolve CRYPTO_num_locks
QSslSocket: cannot resolve CRYPTO_set_id_callback
QSslSocket: cannot resolve CRYPTO_set_locking_callback
QSslSocket: cannot resolve ERR_free_strings
QSslSocket: cannot resolve sk_new_null
QSslSocket: cannot resolve sk_push
QSslSocket: cannot resolve sk_free
QSslSocket: cannot resolve sk_num
QSslSocket: cannot resolve sk_pop_free
QSslSocket: cannot resolve sk_value
QSslSocket: cannot resolve SSL_library_init
QSslSocket: cannot resolve SSL_load_error_strings
QSslSocket: cannot resolve SSLv23_client_method
QSslSocket: cannot resolve SSLv23_server_method
QSslSocket: cannot resolve X509_STORE_CTX_get_chain
QSslSocket: cannot resolve OPENSSL_add_all_algorithms_noconf
QSslSocket: cannot resolve OPENSSL_add_all_algorithms_conf
QSslSocket: cannot resolve SSLeay
QSslSocket: cannot resolve SSLeay_version
QSslSocket: cannot call unresolved function CRYPTO_num_locks
QSslSocket: cannot call unresolved function CRYPTO_set_id_callback
QSslSocket: cannot call unresolved function CRYPTO_set_locking_callback
QSslSocket: cannot call unresolved function SSL_library_init
QSslSocket: cannot call unresolved function SSLv23_client_method
QSslSocket: cannot call unresolved function sk_num
```

Thankfully in [this issue](https://github.com/corollari/lazy-newb-pack-fedora/issues/1), @kd00r managed to find the root of the problem, a missing dependency. After fixing it in our package, I thought this might also be a worthwhile contribution to your package too, so here we go.

Note: All credit goes to @kd00r